### PR TITLE
test: fix integration test workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,7 +7,7 @@ jobs:
   snapd_integration_test:
     strategy:
       matrix:
-        os: ["ubuntu-22.04", "ubuntu-20.04"]
+        os: ["ubuntu-24.04", "ubuntu-22.04"]
     runs-on: ${{ matrix.os }}
     steps:
         # Access to the snapd socket requires root privileges, so these
@@ -23,11 +23,13 @@ jobs:
         run: |
           sudo apt install -y snapd
           sudo systemctl start snapd.service
+      - name: LXD setup
+        uses: canonical/setup-lxd@main
       - name: build test_snap
         run: |
           sudo snap install snapcraft --classic
           cd tests/integration/test_snap
-          snapcraft --destructive-mode
+          snapcraft
           snap download hello-world --basename=hello-world
           cd $GITHUB_WORKSPACE
       - name: integration test


### PR DESCRIPTION
Closes #13

Sample runs:

- [Ubuntu 22.04](https://github.com/st3v3nmw/snap-http/actions/runs/13851718429/job/38760031145?pr=2)
- [Ubuntu 24.04](https://github.com/st3v3nmw/snap-http/actions/runs/13851718429/job/38760030958?pr=2)

I've removed 20.04 because it's being [deprecated](https://github.com/actions/runner-images/issues/11101) and will be unsupported by 2025-04-01.
