### PR TITLE
ci: check if CLA is signed

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,11 @@
+name: Check if CLA is signed
+on:
+    pull_request:
+
+jobs:
+  cla-check:
+    name: Check if CLA is signed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v2


### PR DESCRIPTION
Useful to check now that we're accepting external contributions to this repository.

@Perfect5th 
