### PR TITLE
ci: test on Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: install additional python versions
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa
-          sudo apt install -y python3.8 python3.9 python3.10 python3.11 python3.12
+          sudo apt install -y python3.8 python3.9 python3.10 python3.11 python3.12 python3.13 python3.14
           sudo apt install -y python3.8-distutils python3.9-distutils
       - name: tox unit test
         run: poetry run tox

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ env_list =
     py310
     py311
     py312
+    py313
+    py314
 
 [testenv]
 skip_install = true


### PR DESCRIPTION
This helps prepare for the upcoming release of Ubuntu 26.04, which will have Python 3.14 in its repositories. So far everything works as-is.