### PR TITLE
fix: tpm integration test to use new response format

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,3 +9,5 @@ on:
 jobs:
   snapd_integration_test:
     uses: ./.github/workflows/integration-test.yml
+  tpm_integration_test:
+    uses: ./.github/workflows/integration-tpm.yml

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,6 +2,7 @@ name: Integration Test
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   snapd_integration_test:

--- a/.github/workflows/integration-tpm.yml
+++ b/.github/workflows/integration-tpm.yml
@@ -1,8 +1,7 @@
 name: Integration Test with TPM and FDE
 
 on:
-  schedule:
-    - cron: '0 0 * * 0'
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/tests/integration_tpm/test_api.py
+++ b/tests/integration_tpm/test_api.py
@@ -27,7 +27,7 @@ def test_add_recovery_key():
     generate_result = snap_http.generate_recovery_key().result
     key_id = generate_result["key-id"]
 
-    response = wait_for(snap_http.update_recovery_key)(key_id, "test-add-key", False)
+    response, _ = wait_for(snap_http.update_recovery_key)(key_id, "test-add-key", False)
     assert response.status_code == 202
 
     keyslots = snap_http.get_keyslots().result
@@ -37,7 +37,7 @@ def test_add_recovery_key():
 def test_replace_recovery_key():
     """Test replacing a recovery key."""
     key_id = snap_http.generate_recovery_key().result["key-id"]
-    response = wait_for(snap_http.update_recovery_key)(
+    response, _ = wait_for(snap_http.update_recovery_key)(
         key_id, "test-replace-key", False
     )
     assert response.status_code == 202
@@ -48,7 +48,7 @@ def test_replace_recovery_key():
     )
 
     key_id = snap_http.generate_recovery_key().result["key-id"]
-    response = wait_for(snap_http.update_recovery_key)(key_id, "test-replace-key", True)
+    response, _ = wait_for(snap_http.update_recovery_key)(key_id, "test-replace-key", True)
     assert response.status_code == 202
 
     keyslots = snap_http.get_keyslots().result


### PR DESCRIPTION
I'd missed the tpm integration tests in the change.

Closes #43