### PR TITLE
fix: guard against unknown fields in the snapd JSON response payload

### DIFF
--- a/snap_http/types.py
+++ b/snap_http/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from abc import ABC, abstractproperty
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from functools import cached_property
 from io import BytesIO
 from pathlib import Path
@@ -44,8 +44,15 @@ class SnapdResponse:
     def from_http_response(
         cls: Type["SnapdResponse"], response: Dict[str, Any]
     ) -> SnapdResponse:
-        return cls(**{k.replace("-", "_"): v for k, v in response.items()})
+        # In case snapd returns to us unknown fields in its response
+        cls_fields = {f.name for f in fields(cls)}
+        filtered_fields = {}
 
+        for k, v in response.items():
+            key = k.replace("-", "_")
+            if key in cls_fields:
+                filtered_fields[key] = v
+        return cls(**filtered_fields)
 
 class AbstractRequestBody(ABC):
     """An abstract base class for the request body of a HTTP request."""

--- a/snap_http/types.py
+++ b/snap_http/types.py
@@ -38,6 +38,7 @@ class SnapdResponse:
     change: Union[str, None] = None
     warning_timestamp: Union[str, None] = None
     warning_count: Union[int, None] = None
+    suggested_currency: Union[str, None] = None
 
     @classmethod
     def from_http_response(


### PR DESCRIPTION
I am currently refactoring a `snap` command line wrapper where I am replacing direct subprocess calls with `snap-http`'s lib API, which makes the code cleaner and more efficient. In the process I encountered a `Snapdresponse` dataclass instantiation bug when making a call to the `v2/find` endpoint with the following message `Snapdresponse.__init__() got an unexpected keyword argument 'suggested_currency'`. 

After looking through the codebase I could see that the dataclass was missing a field for the `suggested-currency` JSON field that this particular (maybe other) snapd API endpoint returns.

Adding the missing data field made sense for this particular case, however if there are more such endpoints with undocumented response fields we might want to filter out any currently unregistered dataclass fields from the JSON payload until they are added, no ?

Let me know your thoughts on this :)